### PR TITLE
Use <h2> instead of <h3> for HelpBox titles

### DIFF
--- a/src/components/HelpBox.jsx
+++ b/src/components/HelpBox.jsx
@@ -5,7 +5,7 @@ import './HelpBox.css';
 function HelpBox({ title, text }) {
   return (
     <article className="help-box">
-      <h3>{title}</h3>
+      <h2>{title}</h2>
       <p>{text}</p>
     </article>
   );


### PR DESCRIPTION
This change updates the HelpBox title to use an <h2> tag instead of <h3> for better semantic structure and accessibility. It ensures consistency with the heading hierarchy across the application.